### PR TITLE
Fix Replicate diffusers dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "invisible-watermark",
   "ruff == 0.6.8",
   "accelerate",
+  "diffusers @ git+https://github.com/huggingface/diffusers.git",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add git-based diffusers dependency

## Testing
- `ruff check .`
- `ruff format --check .` *(fails: would reformat 6 files)*

------
https://chatgpt.com/codex/tasks/task_e_685e853a6bec832ba919327385dac6c2